### PR TITLE
fix: Fix missing lib files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
 *
 !/bin/**
-!/lib/**#
-!/package.json
+!/lib/**

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 *
-!/bin/*
-!/lib/*
+!/bin/**
+!/lib/**#
+!/package.json


### PR DESCRIPTION
The package 4.0.0 has missing files.

When we start an application that uses the consul module we get this error.

```
$ node bin/app.js 
internal/modules/cjs/loader.js:582
    throw err;
    ^

Error: Cannot find module './kv/del'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:580:15)
    at Function.Module._load (internal/modules/cjs/loader.js:506:25)
    at Module.require (internal/modules/cjs/loader.js:636:17)
    at require (internal/modules/cjs/helpers.js:20:18)
    at Object.<anonymous> (/Users/stefan/code/plossys/seal-ipp-checkin/node_modules/@sealsystems/consul/lib/consul.js:4:16)
    at Module._compile (internal/modules/cjs/loader.js:688:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:699:10)
    at Module.load (internal/modules/cjs/loader.js:598:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:537:12)
    at Function.Module._load (internal/modules/cjs/loader.js:529:3)
```

It seems that the `.npmignore` filters out some files.
